### PR TITLE
feat: add Repaso Interactivo study mode

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,9 @@
+# Repaso Interactivo – pruebas manuales
+
+- Abrir la app y pulsar **Repaso Interactivo**.
+- Validar respuestas correctas e incorrectas; comprobar feedback.
+- Usar **Siguiente/Anterior** y los atajos `Ctrl+→` / `Ctrl+←`.
+- Presionar *Enter* para validar rápidamente.
+- Recargar la página y confirmar que se mantiene el índice y aciertos.
+- Probar una respuesta alternativa con `|` en el dataset para aceptar variantes.
+- Cambiar el filtro de etiquetas y verificar que la lista se actualiza.

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
           <div class="tabbar">
             <div class="tab active" data-id="plan">Plan</div>
             <div class="tab" data-id="srs">Repaso</div>
+            <div class="tab" data-id="repasoView" id="btnRepasoInteractivo">Repaso Interactivo</div>
             <div class="tab" data-id="quiz">Quiz</div>
             <div class="tab" data-id="exam">Simulador</div>
             <div class="tab" data-id="labs">Labs</div>
@@ -71,6 +72,21 @@
             <button id="refreshSRS" class="btn ghost">Refrescar</button>
           </div>
           <div id="srsBox" style="margin-top:10px"></div>
+        </div>
+      </section>
+
+      <!-- REPASO INTERACTIVO -->
+      <section id="repasoView" class="view" style="display:none">
+        <div class="panel">
+          <h2>Repaso Interactivo</h2>
+          <div class="row">
+            <select id="repasoFilter" class="input" style="max-width:200px"></select>
+            <div class="row" style="flex:1;align-items:center;gap:10px">
+              <div class="progress" style="flex:1"><div id="repasoProgBar"></div></div>
+              <div class="small" id="repasoProgText">0/0 (0%)</div>
+            </div>
+          </div>
+          <div id="repasoCard" style="margin-top:10px"></div>
         </div>
       </section>
 

--- a/study.json
+++ b/study.json
@@ -1,0 +1,42 @@
+[
+  {
+    "concept": "El comando `ls` lista el contenido de un directorio.",
+    "command_example": "ls -l /home",
+    "practice": "¿Qué comando lista en formato largo en el directorio actual?",
+    "answer": "ls -l",
+    "exam_ref": "101.2 - Navegar el sistema de archivos",
+    "tags": ["files", "listing"]
+  },
+  {
+    "concept": "`pwd` muestra la ruta completa del directorio actual.",
+    "command_example": "pwd",
+    "practice": "Estás en `/etc`. ¿Qué comando confirma tu ubicación?",
+    "answer": "pwd",
+    "exam_ref": "101.2 - Navegar el sistema de archivos",
+    "tags": ["filesystem"]
+  },
+  {
+    "concept": "`cd` cambia de directorio.",
+    "command_example": "cd /var/log",
+    "practice": "Escribe el comando para ir a `/usr/local`.",
+    "answer": "cd /usr/local",
+    "exam_ref": "101.2 - Navegar el sistema de archivos",
+    "tags": ["filesystem", "navigation"]
+  },
+  {
+    "concept": "`touch` crea archivos vacíos o actualiza la marca de tiempo.",
+    "command_example": "touch nuevo.txt",
+    "practice": "Crea un archivo vacío llamado `reporte.log`.",
+    "answer": "touch reporte.log",
+    "exam_ref": "103.2 - Manipular archivos",
+    "tags": ["files"]
+  },
+  {
+    "concept": "`cat` muestra el contenido de un archivo.",
+    "command_example": "cat /etc/hostname",
+    "practice": "¿Qué comando muestra `notas.txt`?",
+    "answer": "cat notas.txt",
+    "exam_ref": "103.2 - Manipular archivos",
+    "tags": ["files"]
+  }
+]

--- a/style.css
+++ b/style.css
@@ -83,3 +83,21 @@ body {
 .feedback.ko { background:rgba(160,30,60,.2); border-color:#a61a3b }
 .small { font-size:12px; opacity:.8 }
 
+.card {
+  background:rgba(13,19,39,.65);
+  border:1px solid var(--border);
+  border-radius:16px;
+  padding:16px;
+}
+.concept { font-size:18px; margin-bottom:8px }
+.example {
+  background:#0a1327;
+  padding:8px;
+  border-radius:8px;
+  font-family:monospace;
+  margin-bottom:8px;
+  overflow-x:auto;
+}
+.practice { margin-bottom:8px }
+.nav { display:flex; justify-content:space-between; gap:10px; flex-wrap:wrap; margin-top:10px }
+


### PR DESCRIPTION
## Summary
- add `study.json` dataset for Linux concept practice
- introduce Repaso Interactivo UI with filtering, progress, and keyboard navigation
- implement interactive review logic with persistence and minimal styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3e855a04483268154c17cb0c60151