### PR TITLE
Remove repaso mode and highlight quiz selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,6 @@
           <h1 style="margin:0">LPIC Forge PRO</h1>
           <div class="tabbar">
             <div class="tab active" data-id="plan">Plan</div>
-            <div class="tab" data-id="srs">Repaso</div>
             <div class="tab" data-id="quiz">Quiz</div>
             <div class="tab" data-id="exam">Simulador</div>
             <div class="tab" data-id="labs">Labs</div>
@@ -59,18 +58,6 @@
             <li><b>Días 36–54:</b> Mezcla + reforzar débiles. Simulacro 3× por semana.</li>
             <li><b>Días 55–60:</b> Repaso final y simulacros completos.</li>
           </ol>
-        </div>
-      </section>
-
-      <!-- SRS -->
-      <section id="srs" class="view" style="display:none">
-        <div class="panel">
-          <h2>Repaso SRS</h2>
-          <div class="row">
-            <div class="panel">Pendientes hoy: <b id="dueCount">0</b></div>
-            <button id="refreshSRS" class="btn ghost">Refrescar</button>
-          </div>
-          <div id="srsBox" style="margin-top:10px"></div>
         </div>
       </section>
 

--- a/style.css
+++ b/style.css
@@ -60,6 +60,30 @@ body {
   cursor:pointer
 }
 .tab.active { background:#244073 }
+.quiz-option {
+  display:block;
+  width:100%;
+  text-align:left;
+  margin:8px 0;
+  padding:10px;
+  border:1px solid var(--border);
+  border-radius:10px;
+  background:#0a1327;
+  cursor:pointer;
+  transition:background .1s ease,border-color .1s ease
+}
+.quiz-option.selected {
+  background:rgba(79,137,255,.15);
+  border-color:var(--accent)
+}
+.quiz-option.selected.right {
+  background:rgba(40,120,80,.25);
+  border-color:#1aa46a
+}
+.quiz-option.selected.wrong {
+  background:rgba(160,30,60,.2);
+  border-color:#a61a3b
+}
 .opt {
   display:block;
   width:100%;


### PR DESCRIPTION
## Summary
- remove Repaso tab and section
- safeguard repaso logic to no-op
- highlight quiz selections with keyboard support

## Testing
- `node --check app.js`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c618a7a08326bca0e7636da640d0