### PR TITLE
remove legacy repaso and improve quiz selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,6 @@
           <h1 style="margin:0">LPIC Forge PRO</h1>
           <div class="tabbar">
             <div class="tab active" data-id="plan">Plan</div>
-            <div class="tab" data-id="srs">Repaso</div>
             <div class="tab" data-id="quiz">Quiz</div>
             <div class="tab" data-id="exam">Simulador</div>
             <div class="tab" data-id="labs">Labs</div>
@@ -59,18 +58,6 @@
             <li><b>Días 36–54:</b> Mezcla + reforzar débiles. Simulacro 3× por semana.</li>
             <li><b>Días 55–60:</b> Repaso final y simulacros completos.</li>
           </ol>
-        </div>
-      </section>
-
-      <!-- SRS -->
-      <section id="srs" class="view" style="display:none">
-        <div class="panel">
-          <h2>Repaso SRS</h2>
-          <div class="row">
-            <div class="panel">Pendientes hoy: <b id="dueCount">0</b></div>
-            <button id="refreshSRS" class="btn ghost">Refrescar</button>
-          </div>
-          <div id="srsBox" style="margin-top:10px"></div>
         </div>
       </section>
 

--- a/style.css
+++ b/style.css
@@ -78,6 +78,23 @@ body {
   border-radius:6px;
   padding:2px 6px
 }
+.quiz-option {
+  display:flex;
+  align-items:center;
+  gap:8px;
+  margin:8px 0;
+  padding:10px;
+  border:1px solid var(--border);
+  border-radius:10px;
+  background:#0a1327;
+  cursor:pointer;
+  transition:background .15s,border-color .15s;
+}
+.quiz-option.selected {
+  background:#244073;
+  border-color:var(--accent);
+}
+.quiz-option input { pointer-events:none }
 .feedback { padding:8px 12px; border-radius:10px; margin-top:8px; border:1px solid var(--border) }
 .feedback.ok { background:rgba(40,120,80,.2); border-color:#1aa46a }
 .feedback.ko { background:rgba(160,30,60,.2); border-color:#a61a3b }


### PR DESCRIPTION
## Summary
- drop legacy "Repaso" tab and SRS rendering logic
- allow quiz answers to be changed before moving on and highlight selected option
- add styles for selectable quiz options

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5d81f5e9c83268823cef6990ebd74