### PR TITLE
Remove legacy Repaso tab and improve quiz answer flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,6 @@
           <h1 style="margin:0">LPIC Forge PRO</h1>
           <div class="tabbar">
             <div class="tab active" data-id="plan">Plan</div>
-            <div class="tab" data-id="srs">Repaso</div>
             <div class="tab" data-id="repasoView" id="btnRepasoInteractivo">Repaso Interactivo</div>
             <div class="tab" data-id="quiz">Quiz</div>
             <div class="tab" data-id="exam">Simulador</div>
@@ -60,18 +59,6 @@
             <li><b>Días 36–54:</b> Mezcla + reforzar débiles. Simulacro 3× por semana.</li>
             <li><b>Días 55–60:</b> Repaso final y simulacros completos.</li>
           </ol>
-        </div>
-      </section>
-
-      <!-- SRS -->
-      <section id="srs" class="view" style="display:none">
-        <div class="panel">
-          <h2>Repaso SRS</h2>
-          <div class="row">
-            <div class="panel">Pendientes hoy: <b id="dueCount">0</b></div>
-            <button id="refreshSRS" class="btn ghost">Refrescar</button>
-          </div>
-          <div id="srsBox" style="margin-top:10px"></div>
         </div>
       </section>
 

--- a/style.css
+++ b/style.css
@@ -70,8 +70,11 @@ body {
   border-radius:10px;
   background:#0a1327
 }
-.opt.sel.right { background:rgba(40,120,80,.25); border-color:#1aa46a }
-.opt.sel.wrong { background:rgba(160,30,60,.2); border-color:#a61a3b }
+.opt.selected { background:rgba(79,137,255,.2); border-color:var(--accent) }
+.opt.correct { background:rgba(40,120,80,.25); border-color:#1aa46a }
+.opt.incorrect { background:rgba(160,30,60,.2); border-color:#a61a3b }
+.correct { background:rgba(40,120,80,.25); border-color:#1aa46a }
+.incorrect { background:rgba(160,30,60,.2); border-color:#a61a3b }
 .kbd {
   border:1px solid #3b4b73;
   background:#0e1732;


### PR DESCRIPTION
## Summary
- drop unused SRS 'Repaso' tab and section
- highlight selected quiz answers and show correct/incorrect feedback on submit
- introduce reusable `.selected`, `.correct`, `.incorrect` styles

## Testing
- `npm test` *(fails: ENOENT cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bccec652e08326b2c8f280c313d4eb