### PR TITLE
Remove SRS Repaso tab

### DIFF
--- a/app.js
+++ b/app.js
@@ -208,11 +208,6 @@ function reviewCard(id, ok){
   c.nextDue = nextDue(c.box);
 }
 
-function dueCards(){
-  const now = Date.now();
-  return (Q||[]).filter(q=> (ensureCard(q.id).nextDue||0) <= now );
-}
-
 // Dibujo simple de barras para Dashboard
 function drawTopicsChart(){
   const canvas = $('#chartTopics'); if(!canvas) return;
@@ -295,40 +290,11 @@ async function init(){
   renderRepaso();
   saveRepaso();
 
-  // ----- SRS -----
-  function renderSRS(){
-    const due = dueCards();
-    $('#dueCount').textContent = due.length;
-    const box = $('#srsBox'); box.innerHTML='';
-    if(!due.length){ box.innerHTML='<div class="panel">¡Nada pendiente ahora! Haz un Quiz para añadir tarjetas.</div>'; return; }
-    const q = due[0];
-    const prompt = (q.variants && Math.random()<0.5)? q.variants[0] : q.prompt;
-    const ansText = (q.type==='mcq' ? q.options.filter((_,i)=>q.answer.includes(i)).join(' | ') : q.answer[0]);
-    box.innerHTML = `
-      <div class="panel">
-        <div class="row" style="justify-content:space-between"><small>${q.topic}</small><span class="badge">${q.difficulty}</span></div>
-        <div style="font-size:18px;margin-top:8px"><b>Concepto:</b> ${prompt}</div>
-        <div id="srsInputs" style="margin-top:10px"></div>
-        <div class="row" style="justify-content:space-between;margin-top:8px">
-          <button id="srsReveal" class="btn ghost">Mostrar explicación</button>
-          <div class="row">
-            <button id="srsKO" class="btn ghost">✗ Difícil</button>
-            <button id="srsOK" class="btn">✓ Fácil</button>
-          </div>
-        </div>
-        <div id="srsAns" style="margin-top:8px;display:none">
-          <div class="feedback ok"><b>Respuesta:</b> ${ansText}${q.explanation? ' — '+q.explanation:''}</div>
-        </div>
-      </div>`;
-    if(q.type==='fitb'){ $('#srsInputs').innerHTML = '<input class="input" id="srsInput" placeholder="Respuesta…">'; }
-    if(q.type==='mcq'){ $('#srsInputs').innerHTML = q.options.map((o,i)=>`<div class="opt">${o}</div>`).join(''); }
-    $('#srsReveal').onclick = ()=>{ $('#srsAns').style.display='block'; };
-    $('#srsOK').onclick    = ()=>{ reviewCard(q.id, true); save(); renderSRS(); };
-    $('#srsKO').onclick    = ()=>{ reviewCard(q.id, false); save(); renderSRS(); };
-  }
-  renderSRS();
-  $('#refreshSRS').addEventListener('click', renderSRS);
-  $('#btnRepasoInteractivo').addEventListener('click', ()=>{ tab('repasoView'); renderRepaso(); setTimeout(()=>$('#repasoInput')?.focus(),0); });
+  $('#btnRepasoInteractivo').addEventListener('click', ()=>{
+    tab('repasoView');
+    renderRepaso();
+    setTimeout(()=>$('#repasoInput')?.focus(),0);
+  });
 
   // ----- QUIZ / LECCIÓN -----
   function startQuizGeneric(pool){

--- a/index.html
+++ b/index.html
@@ -15,7 +15,6 @@
           <h1 style="margin:0">LPIC Forge PRO</h1>
           <div class="tabbar">
             <div class="tab active" data-id="plan">Plan</div>
-            <div class="tab" data-id="srs">Repaso</div>
             <div class="tab" data-id="repasoView" id="btnRepasoInteractivo">Repaso Interactivo</div>
             <div class="tab" data-id="quiz">Quiz</div>
             <div class="tab" data-id="exam">Simulador</div>
@@ -60,18 +59,6 @@
             <li><b>Días 36–54:</b> Mezcla + reforzar débiles. Simulacro 3× por semana.</li>
             <li><b>Días 55–60:</b> Repaso final y simulacros completos.</li>
           </ol>
-        </div>
-      </section>
-
-      <!-- SRS -->
-      <section id="srs" class="view" style="display:none">
-        <div class="panel">
-          <h2>Repaso SRS</h2>
-          <div class="row">
-            <div class="panel">Pendientes hoy: <b id="dueCount">0</b></div>
-            <button id="refreshSRS" class="btn ghost">Refrescar</button>
-          </div>
-          <div id="srsBox" style="margin-top:10px"></div>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- remove the obsolete "Repaso" SRS tab and section
- drop associated SRS UI code and listeners
- keep interactive repaso button and functionality

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd27d813883269239bbec8566fedf