### PR TITLE
Add course selection landing and Linux course toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,18 +9,57 @@
     <link rel="stylesheet" href="./style.css">
   </head>
   <body>
-    <div class="wrap">
+    <div class="wrap" id="courseSelect">
+      <header class="panel" style="text-align:center">
+        <h1 style="margin:0">LPIC Forge</h1>
+        <p class="lead">Elige el camino que quieres dominar. Cada curso combina planes de estudio, quizzes y laboratorios prácticos.</p>
+      </header>
+      <div class="panel" style="margin-top:16px">
+        <div class="course-grid">
+          <article class="course-card" data-course="data-science">
+            <span class="course-tag soon">Próximamente</span>
+            <h2>Ciencia de Datos</h2>
+            <p>Aprende Python, estadística aplicada y machine learning con retos guiados.</p>
+            <button class="btn ghost" type="button" data-course-select="data-science" disabled>Explorar</button>
+          </article>
+          <article class="course-card" data-course="linux">
+            <span class="course-tag live">Disponible</span>
+            <h2>Linux</h2>
+            <p>Prepárate para certificaciones como LPIC-1 con planes diarios y simuladores realistas.</p>
+            <button class="btn" type="button" data-course-select="linux">Ingresar</button>
+          </article>
+          <article class="course-card" data-course="datafactory">
+            <span class="course-tag soon">Próximamente</span>
+            <h2>Datafactory</h2>
+            <p>Orquesta pipelines modernos de datos y automatiza despliegues con buenas prácticas.</p>
+            <button class="btn ghost" type="button" data-course-select="datafactory" disabled>Explorar</button>
+          </article>
+          <article class="course-card" data-course="azure">
+            <span class="course-tag soon">Próximamente</span>
+            <h2>Azure</h2>
+            <p>Domina los servicios clave de Azure para arquitecturas en la nube y certificaciones.</p>
+            <button class="btn ghost" type="button" data-course-select="azure" disabled>Explorar</button>
+          </article>
+        </div>
+      </div>
+    </div>
+
+    <div class="wrap" id="appWrap" hidden>
       <header class="panel">
         <div class="row" style="justify-content:space-between;align-items:center">
           <h1 style="margin:0">LPIC Forge PRO</h1>
-          <div class="tabbar">
+          <div class="row" style="align-items:center;gap:10px">
+            <span class="badge" id="courseTag">Selecciona un curso para comenzar</span>
+            <button id="changeCourse" class="btn ghost" style="padding:8px 12px">Cambiar curso</button>
+          </div>
+        </div>
+        <div class="tabbar" style="margin-top:12px">
             <div class="tab active" data-id="plan">Plan</div>
             <div class="tab" data-id="repasoView" id="btnRepasoInteractivo">Repaso Interactivo</div>
             <div class="tab" data-id="quiz">Quiz</div>
             <div class="tab" data-id="exam">Simulador</div>
             <div class="tab" data-id="labs">Labs</div>
             <div class="tab" data-id="dash">Dashboard</div>
-          </div>
         </div>
         <div class="row" style="margin-top:8px">
           <div class="panel" style="padding:6px 10px"><b>Racha:</b> <span id="streak">0</span> días</div>

--- a/style.css
+++ b/style.css
@@ -17,12 +17,44 @@ body {
   color:var(--text);
 }
 .wrap { max-width:980px; margin:24px auto; padding:0 16px }
+.lead { color:var(--muted); margin-top:8px }
 .panel {
   background:rgba(13,19,39,.65);
   border:1px solid var(--border);
   border-radius:16px;
   padding:16px
 }
+.course-grid {
+  display:grid;
+  gap:16px;
+  grid-template-columns:repeat(auto-fit, minmax(220px, 1fr));
+}
+.course-card {
+  background:rgba(12,18,34,.85);
+  border:1px solid var(--border);
+  border-radius:16px;
+  padding:16px;
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+  box-shadow:0 12px 28px rgba(4,11,26,.35);
+}
+.course-card h2 { margin:0 }
+.course-card p { margin:0; color:var(--muted) }
+.course-card .btn { align-self:flex-start }
+.course-card .btn[disabled] { opacity:.6; cursor:not-allowed }
+.course-tag {
+  align-self:flex-start;
+  font-size:12px;
+  letter-spacing:.05em;
+  text-transform:uppercase;
+  padding:4px 10px;
+  border-radius:999px;
+  border:1px solid transparent;
+}
+.course-tag.live { background:rgba(61,214,140,.15); color:var(--good); border-color:rgba(61,214,140,.5); }
+.course-tag.soon { background:rgba(79,137,255,.08); color:var(--muted); border-color:rgba(79,137,255,.3); }
+#appWrap[hidden] { display:none }
 .row { display:flex; gap:10px; flex-wrap:wrap; align-items:center }
 .btn {
   background:#2c3d66;


### PR DESCRIPTION
## Summary
- add a landing view that highlights Ciencia de Datos, Linux, Datafactory y Azure
- keep the LPIC Forge PRO experience behind the Linux selection with a course switcher
- extend styling and application logic to manage course state and banners across views

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e9c948627c83269f66d03d50bdfc31